### PR TITLE
Errors with Status Codes and Handlers throwing errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .stack-work
+.dir-locals.el

--- a/docs/source/tutorial/Introduction.lhs
+++ b/docs/source/tutorial/Introduction.lhs
@@ -16,7 +16,7 @@ import System.Random
 
 import GraphQL
 import GraphQL.API (Object, Field, Argument, (:>), Union)
-import GraphQL.Resolver (Handler, (:<>)(..), unionValue)
+import GraphQL.Resolver (Handler, (:<>)(..), unionValue, AsGraphQLError(..))
 ```
 
 ## A simple GraphQL service
@@ -96,7 +96,7 @@ are `Handler` values.
 Here's a `Handler` for `Hello`:
 
 ```haskell
-hello :: Handler IO Hello
+hello :: (AsGraphQLError e, MonadError e m) => Handler m Hello
 hello = pure greeting
   where
     greeting who = pure ("Hello " <> who <> "!")
@@ -129,7 +129,7 @@ would like.
 Defining a service isn't much point unless you can query. Here's how:
 
 ```haskell
-queryHello :: IO Response
+queryHello :: (AsGraphQLError e, MonadError e m) => m Response
 queryHello = interpretAnonymousQuery @Hello hello "{ greeting(who: \"mort\") }"
 ```
 

--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6aa09d512e2d1e86eeb059e1273005913985418db5c8f94b7361af87744e6bae
+-- hash: e4fd2096e35b0d5bfd0808c695c7af64baaca6c63802470a774b3de65073e972
 
 name:           graphql-api
 version:        0.2.0
@@ -36,6 +36,7 @@ library
     , containers
     , exceptions
     , ghc-prim
+    , mtl
     , protolude >=0.2
     , scientific
     , text
@@ -75,6 +76,7 @@ test-suite graphql-api-doctests
     , base >=4.9 && <5
     , doctest
     , exceptions
+    , mtl
     , protolude >=0.2
     , transformers
   other-modules:
@@ -110,6 +112,7 @@ test-suite graphql-api-tests
     , exceptions
     , graphql-api
     , hspec
+    , mtl
     , protolude >=0.2
     , raw-strings-qq
     , tasty
@@ -144,6 +147,7 @@ benchmark criterion
     , criterion
     , exceptions
     , graphql-api
+    , mtl
     , protolude >=0.2
     , transformers
   other-modules:

--- a/graphql-wai/src/GraphQL/Wai.hs
+++ b/graphql-wai/src/GraphQL/Wai.hs
@@ -11,12 +11,14 @@ import Protolude
 
 import GraphQL (interpretAnonymousQuery)
 import GraphQL.API (HasObjectDefinition)
-import GraphQL.Resolver (HasResolver, Handler)
+import GraphQL.Resolver (HasResolver, Handler, AsGraphQLError)
 import Network.Wai (Application, queryString, responseLBS)
 import GraphQL.Value.ToValue (toValue)
 import Network.HTTP.Types.Header (hContentType)
 import Network.HTTP.Types.Status (status200, status400)
 import qualified Data.Aeson as Aeson
+
+
 
 
 -- | Adapt a GraphQL handler to a WAI application. This is really just
@@ -25,15 +27,14 @@ import qualified Data.Aeson as Aeson
 --
 -- If you have a 'Cat' type and a corresponding 'catHandler' then you
 -- can use "toApplication @Cat catHandler".
-toApplication
-  :: forall r. (HasResolver IO r, HasObjectDefinition r)
-  => Handler IO r -> Application
+toApplication :: forall e m r. (AsGraphQLError e, MonadError e m, HasResolver e m r, HasObjectDefinition r)
+  => Handler m r -> Application
 toApplication handler = app
   where
     app req respond =
       case queryString req of
         [("query", Just query)] -> do
-          r <- interpretAnonymousQuery @r handler (toS query)
+          Right r <- runExceptT $ interpretAnonymousQuery @r handler (toS query)
           let json = Aeson.encode (toValue r)
           respond $ responseLBS status200 [(hContentType, "application/json")] json
         _ -> respond $ responseLBS status400 [] "Must provide excatly one query GET argument."

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ dependencies:
   - exceptions
   - transformers
   - attoparsec
+  - mtl
 
 library:
   source-dirs: src

--- a/src/GraphQL.hs
+++ b/src/GraphQL.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 -- | Interface for GraphQL API.
 --
 -- __Note__: This module is highly subject to change. We're still figuring
@@ -30,7 +31,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 import GraphQL.API (HasObjectDefinition(..))
 import GraphQL.Internal.Execution
   ( VariableValues
-  , ExecutionError
+  , ExecutionError(..)
   , substituteVariables
   )
 import qualified GraphQL.Internal.Execution as Execution
@@ -51,7 +52,12 @@ import GraphQL.Internal.Output
   )
 import GraphQL.Internal.Schema (Schema)
 import qualified GraphQL.Internal.Schema as Schema
-import GraphQL.Resolver (HasResolver(..), Result(..))
+import GraphQL.Resolver
+  ( HasResolver(..)
+  , Result(..)
+  , AsGraphQLError(..)
+  , throwE
+  )
 import GraphQL.Value (Name, NameError, Value, pattern ValueObject)
 
 -- | Errors that can happen while processing a query document.
@@ -85,7 +91,7 @@ instance GraphQLError QueryError where
 
 -- | Execute a GraphQL query.
 executeQuery
-  :: forall api m. (HasResolver m api, Applicative m, HasObjectDefinition api)
+  :: forall api e m. (Applicative m, HasResolver e m api, HasObjectDefinition api)
   => Handler m api -- ^ Handler for the query. This links the query to the code you've written to handle it.
   -> QueryDocument VariableValue  -- ^ A validated query document. Build one with 'compileQuery'.
   -> Maybe Name -- ^ An optional name. If 'Nothing', then executes the only operation in the query. If @Just "something"@, executes the query named @"something".
@@ -94,9 +100,17 @@ executeQuery
 executeQuery handler document name variables =
   case getOperation document name variables of
     Left e -> pure (ExecutionFailure (singleError e))
-    Right operation -> toResult <$> resolve @m @api handler (Just operation)
+    Right operation -> do
+      result <- performOperation operation
+      pure $ toResponse result
   where
-    toResult (Result errors result) =
+    performOperation :: SelectionSetByType Value -> m (Result Value)
+    performOperation operation =
+      resolve @e @m @api handler (Just operation) `catchError` returnError
+
+
+    toResponse :: Result Value -> Response
+    toResponse (Result errors result) =
       case result of
         -- TODO: Prevent this at compile time. Particularly frustrating since
         -- we *know* that api has an object definition.
@@ -106,34 +120,38 @@ executeQuery handler document name variables =
             Just errs -> PartialSuccess object (map toError errs)
         v -> ExecutionFailure (singleError (NonObjectResult v))
 
+    returnError = throwE . asGraphQLError
+
 -- | Create a GraphQL schema.
 makeSchema :: forall api. HasObjectDefinition api => Either QueryError Schema
 makeSchema = first SchemaError (Schema.makeSchema <$> getDefinition @api)
+
 
 -- | Interpet a GraphQL query.
 --
 -- Compiles then executes a GraphQL query.
 interpretQuery
-  :: forall api m. (Applicative m, HasResolver m api, HasObjectDefinition api)
+  :: forall api e m. (Applicative m, HasResolver e m api, HasObjectDefinition api)
   => Handler m api -- ^ Handler for the query. This links the query to the code you've written to handle it.
   -> Text -- ^ The text of a query document. Will be parsed and then executed.
   -> Maybe Name -- ^ An optional name for the operation within document to run. If 'Nothing', execute the only operation in the document. If @Just "something"@, execute the query or mutation named @"something"@.
   -> VariableValues -- ^ Values for variables defined in the query document. A map of 'Variable' to 'Value'.
   -> m Response -- ^ The outcome of running the query.
-interpretQuery handler query name variables =
-  case makeSchema @api >>= flip compileQuery query of
-    Left err -> pure (PreExecutionFailure (toError err :| []))
-    Right document -> executeQuery @api @m handler document name variables
+interpretQuery handler query name variables = do
+    case makeSchema @api >>= flip compileQuery query of
+         Left err -> pure (PreExecutionFailure (toError err :| []))
+         Right document -> executeQuery @api @e @m handler document name variables
+
 
 -- | Interpret an anonymous GraphQL query.
 --
 -- Anonymous queries have no name and take no variables.
 interpretAnonymousQuery
-  :: forall api m. (Applicative m, HasResolver m api, HasObjectDefinition api)
+  :: forall api e m. (Applicative m, HasResolver e m api, HasObjectDefinition api)
   => Handler m api -- ^ Handler for the anonymous query.
   -> Text -- ^ The text of the anonymous query. Should defined only a single, unnamed query operation.
   -> m Response -- ^ The result of running the query.
-interpretAnonymousQuery handler query = interpretQuery @api @m handler query Nothing mempty
+interpretAnonymousQuery handler query = interpretQuery @api @e @m handler query Nothing mempty
 
 -- | Turn some text into a valid query document.
 compileQuery :: Schema -> Text -> Either QueryError (QueryDocument VariableValue)

--- a/src/GraphQL/Internal/Output.hs
+++ b/src/GraphQL/Internal/Output.hs
@@ -81,13 +81,19 @@ instance ToJSON Response where
 
 type Errors = NonEmpty Error
 
-data Error = Error Text [Location] deriving (Eq, Ord, Show)
+data Error = Error Text [Location] Int32 deriving (Eq, Ord, Show)
 
 instance ToValue Error where
-  toValue (Error message []) = unsafeMakeObject [("message", toValue message)]
-  toValue (Error message locations) = unsafeMakeObject [("message", toValue message)
-                                                       ,("locations", toValue locations)
-                                                       ]
+  toValue (Error message [] status) =
+    unsafeMakeObject [ ("message", toValue message)
+                     , ("statusCode", toValue status)
+                     ]
+
+  toValue (Error message locations status) =
+    unsafeMakeObject [ ("message", toValue message)
+                     , ("locations", toValue locations)
+                     , ("statusCode", toValue status)
+                     ]
 
 -- | Make a list of errors containing a single error.
 singleError :: GraphQLError e => e -> Errors
@@ -102,6 +108,7 @@ instance ToValue Location where
                                                     ,("column", toValue column)
                                                     ]
 
+
 -- | An error that arises while processing a GraphQL query.
 class GraphQLError e where
   -- | Represent an error as human-readable text, primarily intended for
@@ -113,7 +120,7 @@ class GraphQLError e where
   -- series of locations within a GraphQL query document. Default
   -- implementation calls 'formatError' and provides no locations.
   toError :: e -> Error
-  toError e = Error (formatError e) []
+  toError e = Error (formatError e) [] 500
 
 -- Defined here to avoid circular dependency.
 instance GraphQLError NameError where

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,6 @@ resolver: nightly-2017-01-25
 packages:
   - "."
   - "./docs/source/tutorial"
-  - "./graphql-wai"
+  # - "./graphql-wai"
 
 extra-deps: [protolude-0.2]

--- a/tests/Examples/UnionExample.hs
+++ b/tests/Examples/UnionExample.hs
@@ -1,30 +1,42 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
 module Examples.UnionExample  where
 
 import Protolude
 import GraphQL.API (Field, List, Object, Union)
 import GraphQL (Response, interpretAnonymousQuery)
-import GraphQL.Resolver (Handler, (:<>)(..), unionValue)
+import GraphQL.Resolver (Handler, (:<>)(..), unionValue, AsGraphQLError(..), ResolverError(..))
 
 -- Slightly reduced example from the spec
 type MiniCat = Object "MiniCat" '[] '[Field "name" Text, Field "meowVolume" Int32]
 type MiniDog = Object "MiniDog" '[] '[Field "barkVolume" Int32]
 
-type CatOrDog = Object "Me" '[] '[Field "myPet" (Union "CatOrDog" '[MiniCat, MiniDog])]
-type CatOrDogList = Object "CatOrDogList" '[] '[Field "pets" (List (Union "CatOrDog" '[MiniCat, MiniDog]))]
+type CatOrDog = Object "Me" '[]
+  '[ Field "myPet" (Union "CatOrDog" '[MiniCat, MiniDog])
+   ]
+type CatOrDogList = Object "CatOrDogList" '[]
+  '[ Field "pets" (List (Union "CatOrDog" '[MiniCat, MiniDog]))
+   ]
 
-miniCat :: Text -> Handler IO MiniCat
+newtype CustomError
+  = UnknownUserID Text
+
+instance AsGraphQLError CustomError where
+  asGraphQLError (UnknownUserID _) = HandlerError "Unknown UserID" 404
+
+miniCat :: (AsGraphQLError e, MonadError e m) => Text -> Handler m MiniCat
 miniCat name = pure (pure name :<> pure 32)
 
-miniDog :: Handler IO MiniDog
+miniDog :: (AsGraphQLError e, MonadError e m) => Handler m MiniDog
 miniDog = pure (pure 100)
 
-catOrDog :: Handler IO CatOrDog
+catOrDog :: (MonadError CustomError m) => Handler m CatOrDog
 catOrDog = pure $ do
   name <- pure "MonadicFelix" -- we can do monadic actions
   unionValue @MiniCat (miniCat name)
 
-catOrDogList :: Handler IO CatOrDogList
+catOrDogList :: (MonadError CustomError m) => Handler m CatOrDogList
 catOrDogList = pure $
   pure [ unionValue @MiniCat (miniCat "Felix")
        , unionValue @MiniCat (miniCat "Mini")
@@ -40,13 +52,21 @@ catOrDogList = pure $
 -- >>> response <- exampleQuery
 -- >>> putStrLn $ encode $ toValue response
 -- {"data":{"myPet":{"meowVolume":32,"name":"MonadicFelix"}}}
-exampleQuery :: IO Response
-exampleQuery = interpretAnonymousQuery @CatOrDog catOrDog "{ myPet { ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } } }"
+exampleQuery :: Monad m => m Response
+exampleQuery = do
+  Right res <- runExceptT $ interpretAnonymousQuery @CatOrDog catOrDog
+    "{ myPet { ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } } }"
+
+  pure res
 
 -- | 'unionValue' can be used in a list context
 --
 -- >>> response <- exampleListQuery
 -- >>> putStrLn $ encode $ toValue response
 -- {"data":{"pets":[{"meowVolume":32,"name":"Felix"},{"meowVolume":32,"name":"Mini"},{"barkVolume":100}]}}
-exampleListQuery :: IO Response
-exampleListQuery = interpretAnonymousQuery @CatOrDogList catOrDogList  "{ pets { ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } } }"
+exampleListQuery :: Monad m => m Response
+exampleListQuery = do
+  Right res <- runExceptT $ interpretAnonymousQuery @CatOrDogList catOrDogList
+    "{ pets { ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } } }"
+
+  pure res

--- a/tests/ResolverTests.hs
+++ b/tests/ResolverTests.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeApplications #-}
+
 module ResolverTests (tests) where
 
 import Protolude hiding (Enum)
@@ -24,13 +27,16 @@ import GraphQL.Resolver
   ( Handler
   , ResolverError(..)
   , (:<>)(..)
+  , AsGraphQLError(..)
   )
 import GraphQL.Internal.Output (singleError)
 
 import EnumTests ( Mode(NormalFile) )
 
+import Control.Monad.Except (MonadError, throwError)
+
 -- Test a custom error monad
-type TMonad = ExceptT Text IO
+type TMonad = ExceptT CustomError IO
 type T = Object "T" '[] '[ Field "z" Int32
                          , Argument "x" Int32 :> Field "t" Int32
                          , Argument "y" Int32 :> Field "q" Int32
@@ -38,8 +44,26 @@ type T = Object "T" '[] '[ Field "z" Int32
 
 tHandler :: Handler TMonad T
 tHandler =
-  pure $ (pure 10) :<> (\tArg -> pure tArg) :<> (pure . (*2))
+  pure $ pure 10 :<> pure :<> (pure . (*2))
 
+-- Allow for throwError with custom error within a handler
+newtype CustomError
+  = UnknownUserID Text
+
+instance AsGraphQLError CustomError where
+  asGraphQLError (UnknownUserID _) = HandlerError "Unknown UserID" 404
+
+type EM = Object "EM" '[]
+  '[ Argument "id" Text :> Field "userName" Text
+   ]
+
+emHandler :: (MonadError CustomError m) => Handler m EM
+emHandler =
+  pure
+    (\id -> case id of
+                "1" -> pure "bob"
+                _   -> throwError $ UnknownUserID id
+    )
 
 -- https://github.com/jml/graphql-api/issues/119
 -- Maybe X didn't descend into its argument. Now it does.
@@ -49,48 +73,63 @@ type Query = Object "Query" '[]
 type Foo = Object "Foo" '[]
   '[ Field "name" Text ]
 
-data ServerFoo = ServerFoo
+newtype ServerFoo = ServerFoo
   { name :: Text
   } deriving (Eq, Show)
 
-lookupFoo :: Text -> IO (Maybe ServerFoo)
+lookupFoo :: (MonadError e m, AsGraphQLError e) => Text -> m (Maybe ServerFoo)
 lookupFoo _ = pure $ Just (ServerFoo "Mort")
 
-viewFoo :: ServerFoo -> Handler IO Foo
-viewFoo ServerFoo { name=name } = pure $ pure $ name
+viewFoo :: (MonadError e m, AsGraphQLError e) => ServerFoo -> Handler m Foo
+viewFoo ServerFoo { name=name } = pure $ pure name
 
-handler :: Handler IO Query
+handler :: (MonadError CustomError m) => Handler m Query
 handler = pure $ \fooId -> do
   foo <- lookupFoo fooId
   -- note that fmap maps over the Maybe, so we still need
   -- have to wrap the result in a pure.
-  sequence $ fmap (pure . viewFoo) foo
+  traverse (pure . viewFoo) foo
 
 -- Enum test
 type EnumQuery = Object "File" '[]
   '[ Field "mode" (Enum "modeEnumName" Mode) ]
 
-enumHandler :: Handler IO EnumQuery
+enumHandler :: (MonadError CustomError m) => Handler m EnumQuery
 enumHandler = pure $ pure NormalFile
 -- /Enum test
 
-tests :: IO TestTree
-tests = testSpec "TypeAPI" $ do
+tests :: (MonadError e m, MonadIO m) => m TestTree
+tests = liftIO $ testSpec "TypeAPI" $ do
   describe "tTest" $ do
     it "works in a simple case" $ do
-      Right (Success object) <- runExceptT (interpretAnonymousQuery @T tHandler "{ t(x: 12) }")
+      Right (Success object) <- runExceptT
+        (interpretAnonymousQuery @T tHandler "{ t(x: 12) }")
       encode object `shouldBe` "{\"t\":12}"
     it "complains about missing field" $ do
-      Right (PartialSuccess _ errs) <- runExceptT (interpretAnonymousQuery @T tHandler "{ not_a_field }")
+      Right (PartialSuccess _ errs) <- runExceptT
+        (interpretAnonymousQuery @T tHandler "{ not_a_field }")
       errs `shouldBe` singleError (FieldNotFoundError "not_a_field")
     it "complains about missing argument" $ do
       Right (PartialSuccess _ errs) <- runExceptT (interpretAnonymousQuery @T tHandler "{ t }")
       errs `shouldBe` singleError (ValueMissing "x")
+
   describe "issue 119" $ do
     it "Just works" $ do
-      Success object <- interpretAnonymousQuery @Query handler "{ test(id: \"10\") { name } }"
+      Right (Success object) <- runExceptT
+        (interpretAnonymousQuery @Query handler "{ test(id: \"10\") { name } }")
       encode object `shouldBe` "{\"test\":{\"name\":\"Mort\"}}"
   describe "Parse, validate and execute queries against API" $ do
     it "API.Enum works" $ do
-      Success object <- interpretAnonymousQuery @EnumQuery enumHandler "{ mode }"
+      Right (Success object) <- runExceptT
+        (interpretAnonymousQuery @EnumQuery enumHandler "{ mode }")
       encode object `shouldBe` "{\"mode\":\"NormalFile\"}"
+
+  describe "emTests" $ do
+    it "finds a user" $ do
+      Right (Success object) <- runExceptT
+        (interpretAnonymousQuery @EM emHandler "{ userName(id: \"1\") }")
+      encode object `shouldBe` "{\"userName\":\"bob\"}"
+    it "adds an error otherwise" $ do
+      Right (PartialSuccess _ errs) <- runExceptT
+        (interpretAnonymousQuery @EM emHandler "{ userName(id: \"gibberish\") }")
+      errs `shouldBe` singleError (HandlerError "Unknown UserID" 404)


### PR DESCRIPTION
- Expands Errors to include statusCodes
- Allows for handlers to throw custom errors

This implementation forced an expansion to the Handler monad used especially in the Resolver module, and also for now requires that interpreting a query be unwrapped to unstack the MonadError itself.

Quite open to a cleaner implementation that accomplishes the same thing, but this is as far as I've gotten for now.