### PR TITLE
feat: Support __typename on all objects

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6aa09d512e2d1e86eeb059e1273005913985418db5c8f94b7361af87744e6bae
+-- hash: e5c7c277493c84f6a6f9319f4549416e303dab15154f87c66f4b305ec27158db
 
 name:           graphql-api
 version:        0.2.0
@@ -84,6 +84,7 @@ test-suite graphql-api-doctests
       Examples.InputObject
       Examples.UnionExample
       ExampleSchema
+      IntrospectionTests
       OrderedMapTests
       ResolverTests
       SchemaTests
@@ -123,6 +124,7 @@ test-suite graphql-api-tests
       Examples.InputObject
       Examples.UnionExample
       ExampleSchema
+      IntrospectionTests
       OrderedMapTests
       ResolverTests
       SchemaTests

--- a/src/GraphQL/Resolver.hs
+++ b/src/GraphQL/Resolver.hs
@@ -388,6 +388,7 @@ instance forall typeName interfaces fields m.
          ( RunFields m (RunFieldsType m fields)
          , API.HasObjectDefinition (API.Object typeName interfaces fields)
          , Monad m
+         , KnownSymbol typeName
          ) => HasResolver m (API.Object typeName interfaces fields) where
   type Handler m (API.Object typeName interfaces fields) = m (RunFieldsHandler m (RunFieldsType m fields))
 
@@ -400,11 +401,15 @@ instance forall typeName interfaces fields m.
         -- This (and other places, including field resolvers) is where user
         -- code can do things like look up something in a database.
         handler <- mHandler
-        r <- traverse (runFields @m @(RunFieldsType m fields) handler) ss
-        let (Result errs obj)  = GValue.objectFromOrderedMap . OrderedMap.catMaybes <$> sequenceA r
+        let (typename, objSelection) = OrderedMap.partition (\_ v -> getName v == "__typename") ss
+        r <- traverse (runFields @m @(RunFieldsType m fields) handler) objSelection
+        let (Result errs obj)  = GValue.objectFromOrderedMap . addTypenameIfRequested typename . OrderedMap.catMaybes <$> sequenceA r
         pure (Result errs (GValue.ValueObject obj))
 
     where
+      addTypenameIfRequested om
+        | null om   = identity
+        | otherwise = OrderedMap.insert "__typename" . toValue $ symbolText @typeName
       getSelectionSet = do
         defn <- first SchemaError $ API.getDefinition @(API.Object typeName interfaces fields)
         -- Fields of a selection set may be behind "type conditions", due to

--- a/tests/IntrospectionTests.hs
+++ b/tests/IntrospectionTests.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE DataKinds   #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module IntrospectionTests (tests) where
+
+import Protolude
+
+import Data.Aeson (toJSON, object, (.=))
+import GraphQL (interpretAnonymousQuery)
+import GraphQL.API (Object, Field)
+import GraphQL.Resolver((:<>)(..), Handler)
+import GraphQL.Value.ToValue (ToValue(..))
+import Test.Tasty (TestTree)
+import Test.Tasty.Hspec
+import Text.RawString.QQ (r)
+
+import ExampleSchema
+
+-- | Example query root.
+--
+-- @
+-- type QueryRoot {
+--   dog: Dog
+-- }
+-- @
+--
+-- Drawn from <https://facebook.github.io/graphql/#sec-Validation>.
+type QueryRoot = Object "QueryRoot" '[]
+  '[ Field "dog" Dog
+   ]
+
+-- | Our server's internal representation of a 'Dog'.
+data ServerDog
+  = ServerDog
+    { name :: Text
+    , nickname :: Maybe Text
+    , barkVolume :: Int32
+    , knownCommands :: Set DogCommand
+    , houseTrainedAtHome :: Bool
+    , houseTrainedElsewhere :: Bool
+    , owner :: ServerHuman
+    }
+
+-- | Whether 'ServerDog' knows the given command.
+doesKnowCommand :: ServerDog -> DogCommand -> Bool
+doesKnowCommand dog command = command `elem` knownCommands dog
+
+-- | Whether 'ServerDog' is house-trained.
+isHouseTrained :: ServerDog -> Maybe Bool -> Bool
+isHouseTrained dog Nothing = houseTrainedAtHome dog || houseTrainedElsewhere dog
+isHouseTrained dog (Just False) = houseTrainedAtHome dog
+isHouseTrained dog (Just True) = houseTrainedElsewhere dog
+
+-- | Present 'ServerDog' for GraphQL.
+viewServerDog :: ServerDog -> Handler IO Dog
+viewServerDog dog@(ServerDog{..}) = pure $
+  pure name :<>
+  pure (fmap pure nickname) :<>
+  pure barkVolume :<>
+  pure . doesKnowCommand dog :<>
+  pure . isHouseTrained dog :<>
+  viewServerHuman owner
+
+-- | jml has a stuffed black dog called "Mortgage".
+mortgage :: ServerDog
+mortgage = ServerDog
+           { name = "Mortgage"
+           , nickname = Just "Mort"
+           , barkVolume = 0  -- He's stuffed
+           , knownCommands = mempty  -- He's stuffed
+           , houseTrainedAtHome = True  -- Never been a problem
+           , houseTrainedElsewhere = True  -- Untested in the field
+           , owner = jml
+           }
+
+-- | Our server's internal representation of a 'Human'.
+data ServerHuman = ServerHuman Text deriving (Eq, Ord, Show)
+
+-- | Present a 'ServerHuman' as a GraphQL 'Human'.
+viewServerHuman :: ServerHuman -> Handler IO Human
+viewServerHuman (ServerHuman name) = pure (pure name)
+
+-- | It me.
+jml :: ServerHuman
+jml = ServerHuman "jml"
+
+
+tests :: IO TestTree
+tests = testSpec "Introspection" $ do
+  it "supports __typename on regular objects" $ do
+    let root = pure (viewServerDog mortgage)
+        query = [r|{
+                    dog {
+                      __typename
+                    }
+                  }|]
+    response <- interpretAnonymousQuery @QueryRoot root query
+    let expected =
+          object
+          [ "data" .= object
+            [ "dog" .= object
+              [ "__typename" .= ("Dog" :: Text) ]]]
+    toJSON (toValue response) `shouldBe` expected
+
+

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -14,6 +14,7 @@ import qualified SchemaTests
 import qualified ValidationTests
 import qualified ValueTests
 import qualified EnumTests ()
+import qualified IntrospectionTests
 
 -- import examples to ensure they compile
 import Examples.InputObject ()
@@ -32,4 +33,5 @@ main = do
       , SchemaTests.tests
       , ValidationTests.tests
       , ValueTests.tests
+      , IntrospectionTests.tests
       ]


### PR DESCRIPTION
Support a __typename introspection field on all queried objects. When requested,
it returns a string representing the name of the object type being queried.