### PR TITLE
feat: Support __typename on all objects

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e4fd2096e35b0d5bfd0808c695c7af64baaca6c63802470a774b3de65073e972
+-- hash: 8695559b84eae41fcf8dcf2f321f5988d41742f787d96dcb8dbb0e005807219b
 
 name:           graphql-api
 version:        0.2.0
@@ -86,6 +86,7 @@ test-suite graphql-api-doctests
       Examples.InputObject
       Examples.UnionExample
       ExampleSchema
+      IntrospectionTests
       OrderedMapTests
       ResolverTests
       SchemaTests
@@ -126,6 +127,7 @@ test-suite graphql-api-tests
       Examples.InputObject
       Examples.UnionExample
       ExampleSchema
+      IntrospectionTests
       OrderedMapTests
       ResolverTests
       SchemaTests

--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8695559b84eae41fcf8dcf2f321f5988d41742f787d96dcb8dbb0e005807219b
+-- hash: de70417840e8f6e28f1e79a925e31212e0b625d88c0ad623fa7c3b05156085ae
 
 name:           graphql-api
 version:        0.2.0
@@ -36,6 +36,7 @@ library
     , containers
     , exceptions
     , ghc-prim
+    , lens
     , mtl
     , protolude >=0.2
     , scientific
@@ -76,6 +77,7 @@ test-suite graphql-api-doctests
     , base >=4.9 && <5
     , doctest
     , exceptions
+    , lens
     , mtl
     , protolude >=0.2
     , transformers
@@ -113,6 +115,7 @@ test-suite graphql-api-tests
     , exceptions
     , graphql-api
     , hspec
+    , lens
     , mtl
     , protolude >=0.2
     , raw-strings-qq
@@ -149,6 +152,7 @@ benchmark criterion
     , criterion
     , exceptions
     , graphql-api
+    , lens
     , mtl
     , protolude >=0.2
     , transformers

--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ dependencies:
   - transformers
   - attoparsec
   - mtl
+  - lens
 
 library:
   source-dirs: src

--- a/src/GraphQL/Resolver.hs
+++ b/src/GraphQL/Resolver.hs
@@ -127,6 +127,10 @@ class AsGraphQLError e where
 instance AsGraphQLError ResolverError where
   asGraphQLError err = err
 
+instance AsGraphQLError IOException where
+  asGraphQLError _ = UncaughtHandlerError
+
+
 -- | Object field separation operator.
 --
 -- Use this to provide handlers for fields of an object.

--- a/tests/IntrospectionTests.hs
+++ b/tests/IntrospectionTests.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE DataKinds   #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module IntrospectionTests (tests) where
+
+import Protolude
+
+import Data.Aeson (toJSON, object, (.=))
+import GraphQL (interpretAnonymousQuery)
+import GraphQL.API (Object, Field)
+import GraphQL.Resolver((:<>)(..), Handler)
+import GraphQL.Value.ToValue (ToValue(..))
+import Test.Tasty (TestTree)
+import Test.Tasty.Hspec
+import Text.RawString.QQ (r)
+
+import ExampleSchema
+
+-- | Example query root.
+--
+-- @
+-- type QueryRoot {
+--   dog: Dog
+-- }
+-- @
+--
+-- Drawn from <https://facebook.github.io/graphql/#sec-Validation>.
+type QueryRoot = Object "QueryRoot" '[]
+  '[ Field "dog" Dog
+   ]
+
+-- | Our server's internal representation of a 'Dog'.
+data ServerDog
+  = ServerDog
+    { name :: Text
+    , nickname :: Maybe Text
+    , barkVolume :: Int32
+    , knownCommands :: Set DogCommand
+    , houseTrainedAtHome :: Bool
+    , houseTrainedElsewhere :: Bool
+    , owner :: ServerHuman
+    }
+
+-- | Whether 'ServerDog' knows the given command.
+doesKnowCommand :: ServerDog -> DogCommand -> Bool
+doesKnowCommand dog command = command `elem` knownCommands dog
+
+-- | Whether 'ServerDog' is house-trained.
+isHouseTrained :: ServerDog -> Maybe Bool -> Bool
+isHouseTrained dog Nothing = houseTrainedAtHome dog || houseTrainedElsewhere dog
+isHouseTrained dog (Just False) = houseTrainedAtHome dog
+isHouseTrained dog (Just True) = houseTrainedElsewhere dog
+
+-- | Present 'ServerDog' for GraphQL.
+viewServerDog :: ServerDog -> Handler IO Dog
+viewServerDog dog@(ServerDog{..}) = pure $
+  pure name :<>
+  pure (fmap pure nickname) :<>
+  pure barkVolume :<>
+  pure . doesKnowCommand dog :<>
+  pure . isHouseTrained dog :<>
+  viewServerHuman owner
+
+-- | jml has a stuffed black dog called "Mortgage".
+mortgage :: ServerDog
+mortgage = ServerDog
+           { name = "Mortgage"
+           , nickname = Just "Mort"
+           , barkVolume = 0  -- He's stuffed
+           , knownCommands = mempty  -- He's stuffed
+           , houseTrainedAtHome = True  -- Never been a problem
+           , houseTrainedElsewhere = True  -- Untested in the field
+           , owner = jml
+           }
+
+-- | Our server's internal representation of a 'Human'.
+data ServerHuman = ServerHuman Text deriving (Eq, Ord, Show)
+
+-- | Present a 'ServerHuman' as a GraphQL 'Human'.
+viewServerHuman :: ServerHuman -> Handler IO Human
+viewServerHuman (ServerHuman name) = pure (pure name)
+
+-- | It me.
+jml :: ServerHuman
+jml = ServerHuman "jml"
+
+
+tests :: IO TestTree
+tests = testSpec "Introspection" $ do
+  it "supports __typename on regular objects" $ do
+    let root = pure (viewServerDog mortgage)
+        query = [r|{
+                    dog {
+                      __typename
+                    }
+                  }|]
+    response <- interpretAnonymousQuery @QueryRoot root query
+    let expected =
+          object
+          [ "data" .= object
+            [ "dog" .= object
+              [ "__typename" .= ("Dog" :: Text) ]]]
+    toJSON (toValue response) `shouldBe` expected
+
+

--- a/tests/IntrospectionTests.hs
+++ b/tests/IntrospectionTests.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE DataKinds   #-}
-{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE QuasiQuotes      #-}
+{-# LANGUAGE TypeApplications #-}
 
 module IntrospectionTests (tests) where
 
@@ -53,7 +54,7 @@ isHouseTrained dog (Just True) = houseTrainedElsewhere dog
 
 -- | Present 'ServerDog' for GraphQL.
 viewServerDog :: ServerDog -> Handler IO Dog
-viewServerDog dog@(ServerDog{..}) = pure $
+viewServerDog dog@ServerDog{..} = pure $
   pure name :<>
   pure (fmap pure nickname) :<>
   pure barkVolume :<>
@@ -74,7 +75,7 @@ mortgage = ServerDog
            }
 
 -- | Our server's internal representation of a 'Human'.
-data ServerHuman = ServerHuman Text deriving (Eq, Ord, Show)
+newtype ServerHuman = ServerHuman Text deriving (Eq, Ord, Show)
 
 -- | Present a 'ServerHuman' as a GraphQL 'Human'.
 viewServerHuman :: ServerHuman -> Handler IO Human
@@ -83,7 +84,6 @@ viewServerHuman (ServerHuman name) = pure (pure name)
 -- | It me.
 jml :: ServerHuman
 jml = ServerHuman "jml"
-
 
 tests :: IO TestTree
 tests = testSpec "Introspection" $ do
@@ -94,12 +94,12 @@ tests = testSpec "Introspection" $ do
                       __typename
                     }
                   }|]
-    response <- interpretAnonymousQuery @QueryRoot root query
-    let expected =
-          object
+        expected = object
           [ "data" .= object
             [ "dog" .= object
               [ "__typename" .= ("Dog" :: Text) ]]]
-    toJSON (toValue response) `shouldBe` expected
 
+    response <- interpretAnonymousQuery @QueryRoot root query
+
+    toJSON (toValue response) `shouldBe` expected
 

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -14,6 +14,7 @@ import qualified SchemaTests
 import qualified ValidationTests
 import qualified ValueTests
 import qualified EnumTests ()
+import qualified IntrospectionTests
 
 -- import examples to ensure they compile
 import Examples.InputObject ()
@@ -32,4 +33,5 @@ main = do
       , SchemaTests.tests
       , ValidationTests.tests
       , ValueTests.tests
+      , IntrospectionTests.tests
       ]


### PR DESCRIPTION
Support a __typename introspection field on all queried objects. When requested,
it returns a string representing the name of the object type being queried.